### PR TITLE
feat: sync user mappings after role grant/revoke

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -58,6 +58,38 @@ When the new API credential is created, carefully copy and save the **Client ID*
 
 **That's it!** Next, move on to the connector configuration instructions. 
 
+## Enable automatic user mapping sync (optional)
+
+When C1 grants or revokes a role, OneLogin's user mapping rules are not automatically re-evaluated. If you have mapping rules that should take effect immediately after a role change, you can enable **Apply user mappings**. When enabled, the connector instructs OneLogin to re-evaluate and apply all user mapping rules immediately after every role grant or revoke.
+
+This feature requires a custom user field named `c1_last_action` to exist in your OneLogin account before you enable it.
+
+### Create the c1_last_action custom user field
+
+<Warning>
+A user with **Administrator** or **account owner** access to your OneLogin account must perform this task.
+</Warning>
+
+<Steps>
+<Step>
+Sign into OneLogin as an **Account owner** or **Administrator**.
+</Step>
+<Step>
+Navigate to **Users** > **Custom User Fields**.
+</Step>
+<Step>
+Click **New User Field**.
+</Step>
+<Step>
+Set the **Name** to `c1_last_action` and the **Shortname** to `c1_last_action`.
+</Step>
+<Step>
+Click **Save**.
+</Step>
+</Steps>
+
+Once the field exists, enable the **Apply user mappings** option when configuring the connector (see below).
+
 ## Configure the OneLogin connector
 
 <Warning>

--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -8,6 +8,7 @@ type Onelogin struct {
 	OneloginClientSecret string `mapstructure:"onelogin-client-secret"`
 	Subdomain string `mapstructure:"subdomain"`
 	PrivilegesEnabled bool `mapstructure:"privileges-enabled"`
+	ApplyUserMappings bool `mapstructure:"apply-user-mappings"`
 }
 
 func (c *Onelogin) findFieldByTag(tagValue string) (any, bool) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -36,7 +36,7 @@ var OneLoginEnablePrivileges = field.BoolField(
 var ApplyUserMappings = field.BoolField(
 	"apply-user-mappings",
 	field.WithDisplayName("Apply User Mappings"),
-	field.WithDescription("If true, will run OneLogin user mappings immediately upon a role grant/revoke request"),
+	field.WithDescription("If true, will run OneLogin user mappings immediately upon a role grant/revoke request. Requires a custom user field in OneLogin called c1_last_action."),
 	field.WithDefaultValue(false),
 )
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -33,6 +33,13 @@ var OneLoginEnablePrivileges = field.BoolField(
 	field.WithDefaultValue(false),
 )
 
+var ApplyUserMappings = field.BoolField(
+	"apply-user-mappings",
+	field.WithDisplayName("Apply User Mappings"),
+	field.WithDescription("If true, will run OneLogin user mappings immediately upon a role grant/revoke request"),
+	field.WithDefaultValue(false),
+)
+
 //go:generate go run ./gen
 var Config = field.NewConfiguration(
 	[]field.SchemaField{
@@ -40,6 +47,7 @@ var Config = field.NewConfiguration(
 		OneLoginClientSecret,
 		OneLoginSubDomain,
 		OneLoginEnablePrivileges,
+		ApplyUserMappings,
 	},
 	field.WithConnectorDisplayName("OneLogin"),
 	field.WithHelpUrl("/docs/baton/onelogin-v2"),

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -57,14 +57,15 @@ var (
 )
 
 type OneLogin struct {
-	client         *onelogin.Client
-	syncPrivileges bool
+	client            *onelogin.Client
+	syncPrivileges    bool
+	applyUserMappings bool
 }
 
 func (o *OneLogin) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceSyncerV2 {
 	resources := []connectorbuilder.ResourceSyncerV2{
 		userBuilder(o.client),
-		roleBuilder(o.client),
+		roleBuilder(o.client, o.applyUserMappings),
 		appBuilder(o.client),
 		groupBuilder(o.client),
 	}
@@ -94,15 +95,16 @@ func (o *OneLogin) Validate(ctx context.Context) (annotations.Annotations, error
 }
 
 // New returns the OneLogin connector.
-func NewConnector(ctx context.Context, clientId, clientSecret, subdomain string, syncPrivileges bool) (*OneLogin, error) {
+func NewConnector(ctx context.Context, clientId, clientSecret, subdomain string, syncPrivileges bool, applyUserMappings bool) (*OneLogin, error) {
 	oneLoginClient, err := onelogin.NewClient(ctx, clientId, clientSecret, subdomain)
 	if err != nil {
 		return nil, fmt.Errorf("onelogin-connector: failed to initialize OneLogin client: %w", err)
 	}
 
 	return &OneLogin{
-		client:         oneLoginClient,
-		syncPrivileges: syncPrivileges,
+		client:            oneLoginClient,
+		syncPrivileges:    syncPrivileges,
+		applyUserMappings: applyUserMappings,
 	}, nil
 }
 
@@ -121,6 +123,7 @@ func New(ctx context.Context, config *cfg.Onelogin, opts *cli.ConnectorOpts) (co
 		config.OneloginClientSecret,
 		subdomain,
 		config.PrivilegesEnabled,
+		config.ApplyUserMappings,
 	)
 	if err != nil {
 		l.Error("error creating connector", zap.Error(err))

--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -26,8 +26,9 @@ const (
 )
 
 type roleResourceType struct {
-	resourceType *v2.ResourceType
-	client       *onelogin.Client
+	resourceType      *v2.ResourceType
+	client            *onelogin.Client
+	applyUserMappings bool
 }
 
 func (r *roleResourceType) ResourceType(_ context.Context) *v2.ResourceType {
@@ -308,11 +309,13 @@ func (r *roleResourceType) Grant(ctx context.Context, principal *v2.Resource, en
 		return nil, fmt.Errorf("onelogin-connector: failed to grant %s role: %w", entitlement.Slug, err)
 	}
 
-	if err := r.client.SyncUserMappings(ctx, principal.Id.Resource); err != nil {
-		l.Warn("onelogin-connector: failed to sync user mappings after role grant",
-			zap.String("user_id", principal.Id.Resource),
-			zap.Error(err),
-		)
+	if r.applyUserMappings {
+		if err := r.client.SyncUserMappings(ctx, principal.Id.Resource); err != nil {
+			l.Warn("onelogin-connector: failed to sync user mappings after role grant",
+				zap.String("user_id", principal.Id.Resource),
+				zap.Error(err),
+			)
+		}
 	}
 
 	return nil, nil
@@ -341,19 +344,22 @@ func (r *roleResourceType) Revoke(ctx context.Context, grant *v2.Grant) (annotat
 		return nil, fmt.Errorf("onelogin-connector failed to revoke %s role: %w", entitlement.Slug, err)
 	}
 
-	if err := r.client.SyncUserMappings(ctx, principal.Id.Resource); err != nil {
-		l.Warn("onelogin-connector: failed to sync user mappings after role revoke",
-			zap.String("user_id", principal.Id.Resource),
-			zap.Error(err),
-		)
+	if r.applyUserMappings {
+		if err := r.client.SyncUserMappings(ctx, principal.Id.Resource); err != nil {
+			l.Warn("onelogin-connector: failed to sync user mappings after role revoke",
+				zap.String("user_id", principal.Id.Resource),
+				zap.Error(err),
+			)
+		}
 	}
 
 	return nil, nil
 }
 
-func roleBuilder(client *onelogin.Client) *roleResourceType {
+func roleBuilder(client *onelogin.Client, applyUserMappings bool) *roleResourceType {
 	return &roleResourceType{
-		resourceType: resourceTypeRole,
-		client:       client,
+		resourceType:      resourceTypeRole,
+		client:            client,
+		applyUserMappings: applyUserMappings,
 	}
 }

--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -308,6 +308,13 @@ func (r *roleResourceType) Grant(ctx context.Context, principal *v2.Resource, en
 		return nil, fmt.Errorf("onelogin-connector: failed to grant %s role: %w", entitlement.Slug, err)
 	}
 
+	if err := r.client.SyncUserMappings(ctx, principal.Id.Resource); err != nil {
+		l.Warn("onelogin-connector: failed to sync user mappings after role grant",
+			zap.String("user_id", principal.Id.Resource),
+			zap.Error(err),
+		)
+	}
+
 	return nil, nil
 }
 
@@ -332,6 +339,13 @@ func (r *roleResourceType) Revoke(ctx context.Context, grant *v2.Grant) (annotat
 	err := r.client.RevokeRole(ctx, entitlement.Resource.Id.Resource, principal.Id.Resource, entitlement.Slug)
 	if err != nil {
 		return nil, fmt.Errorf("onelogin-connector failed to revoke %s role: %w", entitlement.Slug, err)
+	}
+
+	if err := r.client.SyncUserMappings(ctx, principal.Id.Resource); err != nil {
+		l.Warn("onelogin-connector: failed to sync user mappings after role revoke",
+			zap.String("user_id", principal.Id.Resource),
+			zap.Error(err),
+		)
 	}
 
 	return nil, nil

--- a/pkg/onelogin/client.go
+++ b/pkg/onelogin/client.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"time"
 
 	"github.com/conductorone/baton-sdk/pkg/uhttp"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
@@ -311,6 +312,33 @@ func (c *Client) RevokeRole(ctx context.Context, roleId, userId, entitlement str
 	)
 	if err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func (c *Client) SyncUserMappings(ctx context.Context, userID string) error {
+	var updateResponse User
+
+	payload, err := json.Marshal(UserUpdatePayload{
+		CustomAttributes: map[string]interface{}{
+			"c1_last_action": time.Now().Unix(),
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("onelogin-connector: failed to marshal sync mappings payload for user %s: %w", userID, err)
+	}
+
+	_, err = c.doRequest(
+		ctx,
+		fmt.Sprintf(UserBaseUrl, c.subdomain, userID),
+		http.MethodPut,
+		&updateResponse,
+		payload,
+		&MappingsSyncParam{},
+	)
+	if err != nil {
+		return fmt.Errorf("onelogin-connector: failed to sync mappings for user %s: %w", userID, err)
 	}
 
 	return nil

--- a/pkg/onelogin/client.go
+++ b/pkg/onelogin/client.go
@@ -37,6 +37,8 @@ const (
 	GetPrivilegeByIdBaseURL            = PrivilegesBaseURL + "/%s"
 	GetPrivilegeAssignableRolesBaseUrl = PrivilegesBaseURL + "/%s/roles"
 	GetPrivilegeAssignableUsersBaseUrl = PrivilegesBaseURL + "/%s/users"
+
+	c1LastActionAttr = "c1_last_action"
 )
 
 type Client struct {
@@ -322,7 +324,7 @@ func (c *Client) SyncUserMappings(ctx context.Context, userID string) error {
 
 	payload, err := json.Marshal(UserUpdatePayload{
 		CustomAttributes: map[string]interface{}{
-			"c1_last_action": time.Now().Unix(),
+			c1LastActionAttr: time.Now().Unix(),
 		},
 	})
 	if err != nil {

--- a/pkg/onelogin/request.go
+++ b/pkg/onelogin/request.go
@@ -80,3 +80,15 @@ func NewCredentialsGrant() *GrantBody {
 		GrantType: "client_credentials",
 	}
 }
+
+// MappingsSyncParam instructs OneLogin to reapply user mappings synchronously.
+type MappingsSyncParam struct{}
+
+func (m *MappingsSyncParam) setup(params *url.Values) {
+	params.Set("mappings", "sync")
+}
+
+// UserUpdatePayload is the request body for PUT /api/2/users/{id}.
+type UserUpdatePayload struct {
+	CustomAttributes map[string]interface{} `json:"custom_attributes"`
+}

--- a/pkg/onelogin/request_test.go
+++ b/pkg/onelogin/request_test.go
@@ -1,0 +1,45 @@
+package onelogin
+
+import (
+	"encoding/json"
+	"net/url"
+	"testing"
+	"time"
+)
+
+func TestMappingsSyncParam_Setup(t *testing.T) {
+	params := url.Values{}
+	p := &MappingsSyncParam{}
+	p.setup(&params)
+
+	if got := params.Get("mappings"); got != "sync" {
+		t.Errorf("expected mappings=sync, got mappings=%s", got)
+	}
+}
+
+func TestUserUpdatePayload_Marshal(t *testing.T) {
+	ts := time.Now().Unix()
+	payload := UserUpdatePayload{
+		CustomAttributes: map[string]interface{}{
+			"c1_last_action": ts,
+		},
+	}
+
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("unexpected marshal error: %v", err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+
+	attrs, ok := result["custom_attributes"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected custom_attributes to be a map")
+	}
+	if _, ok := attrs["c1_last_action"]; !ok {
+		t.Error("expected c1_last_action key in custom_attributes")
+	}
+}


### PR DESCRIPTION
## Summary

Due to OneLogin's API eventual consistency, role changes made by C1 are processed asynchronously — meaning there's a delay before the change is reflected in OneLogin.

- After a successful role grant or revoke, calls \`PUT /api/2/users/{id}?mappings=sync\` to force OneLogin to synchronously reapply user mappings
- Uses a \`c1_last_action\` Unix timestamp in the \`custom_attributes\` payload to guarantee a real mutation on every call
- Mapping sync is gated behind a new \`--apply-user-mappings\` flag (default \`false\`) — existing deployments are unaffected unless they opt in
- Mapping sync failures are non-fatal: logged as a warning, the provisioning operation still reports success

## Test Plan

- [x] Run connector without \`--apply-user-mappings\`: grant/revoke a role and confirm no PUT to \`/api/2/users/{id}\` is made
- [x] Run connector with \`--apply-user-mappings\`: grant a role and confirm mappings are reapplied in OneLogin
- [x] Run connector with \`--apply-user-mappings\`: revoke a role and confirm mappings are reapplied in OneLogin
- [x] Verify that a mapping sync failure logs a warning but does not fail the grant/revoke task